### PR TITLE
Fix Manual Typo(s) on Four-Card Monte

### DIFF
--- a/Manual/Manual.html
+++ b/Manual/Manual.html
@@ -64,7 +64,7 @@
 							<li>Otherwise, if all cards are from different suits, press the 1st coin.</li>
 							<li>Otherwise, if there are 2 Spades and 2 Clubs, press the 2nd card.</li>
 							<li>Otherwise, if you have 2 Hearts and 2 Diamonds, press the 4th coin.</li>
-							<li>Otherwise, if you have 2 pairs, press the 3rd card.</li>
+							<li>Otherwise, if you have 2 pairs, press the 3rd coin.</li>
 							<li>If none apply and the serial number has a vowel, take the last digit of the serial number. Else take the first digit. If it’s higher than 4, subtract 4.</li>
 							<li>If you get a 1, press the 1st coin. If you get a 2, press the 2nd. Etc.</li>
 						</ul>

--- a/Manual/Manual.html
+++ b/Manual/Manual.html
@@ -62,7 +62,7 @@
 							<li>Otherwise, if you have a Queen Of Hearts and there’s any king present as well, press the 2nd coin.</li>
 							<li>Otherwise, if an Ace of Diamonds is present and you don’t have duplicate coins, press the 3rd coin.</li>
 							<li>Otherwise, if all cards are from different suits, press the 1st coin.</li>
-							<li>Otherwise, if there are 2 Spades and 2 Clubs, press the 2nd card.</li>
+							<li>Otherwise, if there are 2 Spades and 2 Clubs, press the 2nd coin.</li>
 							<li>Otherwise, if you have 2 Hearts and 2 Diamonds, press the 4th coin.</li>
 							<li>Otherwise, if you have 2 pairs, press the 3rd coin.</li>
 							<li>If none apply and the serial number has a vowel, take the last digit of the serial number. Else take the first digit. If it’s higher than 4, subtract 4.</li>


### PR DESCRIPTION
For choosing the correct coin, do not refer to choosing the correct card.